### PR TITLE
Remove Cosmos defaultIdentity

### DIFF
--- a/infra/modules/cosmos.bicep
+++ b/infra/modules/cosmos.bicep
@@ -50,7 +50,6 @@ resource account 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
   kind: 'GlobalDocumentDB'
   properties: {
     databaseAccountOfferType: 'Standard'
-    defaultIdentity: 'SystemAssignedIdentity'
     locations: [
       {
         locationName: location


### PR DESCRIPTION
Cannot set the default identity during deployment, so removed it.