### PR TITLE
Fix the image reference for ACA

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -78,7 +78,7 @@ jobs:
       attestations: write
       id-token: write
     outputs:
-      image-tag: ${{ steps.meta.outputs.tags[0] }}
+      image-tag: ${{ steps.meta.outputs.bake-file-tags[0] }}
     steps:
       - uses: actions/checkout@v4
       - name: Login to Docker Hub


### PR DESCRIPTION
The ACA isn't getting the correct image reference from the docker meta output. Using the bake-file-tags should work