### PR TITLE
Remove cosmos default from appsettings.json

### DIFF
--- a/src/api/Menlo.Api/appsettings.json
+++ b/src/api/Menlo.Api/appsettings.json
@@ -17,8 +17,5 @@
             "Default": "Information",
             "Microsoft.AspNetCore": "Warning"
         }
-    },
-    "RepositoryOptions": {
-        "CosmosConnectionString": "get-from-emulator"
     }
 }


### PR DESCRIPTION
Removing the default cosmos connection from appsettings.json as it is throwing an exception