### PR TITLE
Temprary fix: Azure CLI and Bicep mishap

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -132,6 +132,8 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
+            tdnf install -y icu
+            tdnf install –y jq
             az deployment group create \
               --resource-group ${{ secrets.RESOURCE_GROUP_NAME }} \
               --parameters infra/main.bicepparam \


### PR DESCRIPTION
Temporarily fixing this misshap by the Azure CLI and Bicep team missing a big breaking change.

https://techcommunity.microsoft.com/t5/azure-tools-blog/azure-cli-docker-container-base-linux-image-is-now-azure-linux/ba-p/4236248