### PR TITLE
Fix auth redirecting to HTTPs in Docker

### DIFF
--- a/src/api/Menlo.Api/Auth/AuthHostExtensions.cs
+++ b/src/api/Menlo.Api/Auth/AuthHostExtensions.cs
@@ -1,0 +1,38 @@
+namespace Menlo.Auth;
+
+public static class AuthHostExtensions
+{
+    public static AuthorizationBuilder AddAuth(this WebApplicationBuilder builder)
+    {
+        MicrosoftIdentityOptions? azureAdOptions = builder.Configuration
+            .GetSection("AzureAd")
+            .Get<MicrosoftIdentityOptions>();
+        if (azureAdOptions is null)
+        {
+            throw new InvalidOperationException("AzureAd section is missing from configuration");
+        }
+
+        builder.Services
+            .AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
+            .AddMicrosoftIdentityWebApp(options =>
+            {
+                options.ClientId = azureAdOptions.ClientId;
+                options.ClientSecret = azureAdOptions.ClientSecret;
+                options.Domain = azureAdOptions.Domain;
+                options.Instance = azureAdOptions.Instance;
+                options.TenantId = azureAdOptions.TenantId;
+                options.CallbackPath = azureAdOptions.CallbackPath;
+                options.SignedOutCallbackPath = azureAdOptions.SignedOutCallbackPath;
+
+                options.Events.OnRedirectToIdentityProvider = ctx =>
+                {
+                    ctx.ProtocolMessage.RedirectUri = ctx.ProtocolMessage.RedirectUri.Replace("http://", "https://", StringComparison.OrdinalIgnoreCase);
+                    return Task.CompletedTask;
+                };
+            });
+
+        return builder.Services
+            .AddAuthorizationBuilder()
+            .AddPolicy(AuthConstants.PolicyNameAuthenticatedUsersOnly, op => op.RequireAuthenticatedUser().Build());
+    }
+}

--- a/src/api/Menlo.Api/Program.cs
+++ b/src/api/Menlo.Api/Program.cs
@@ -13,15 +13,16 @@ builder.Services
     .AddHealthChecks()
     .AddCosmosRepository();
 
-builder.Services.Configure<ForwardedHeadersOptions>(options => options.ForwardedHeaders =
-        ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto);
-
-builder.Services.AddMicrosoftIdentityWebAppAuthentication(builder.Configuration);
-
 builder.Services
-    .AddAuthorizationBuilder()
-    .AddPolicy(AuthConstants.PolicyNameAuthenticatedUsersOnly, op => op.RequireAuthenticatedUser().Build())
-    .AddUtilitiesPolicy();
+    .Configure<ForwardedHeadersOptions>(options => options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto);
+
+MicrosoftIdentityOptions? azureAdOptions = builder.Configuration.GetSection("AzureAd").Get<MicrosoftIdentityOptions>();
+if (azureAdOptions is null)
+{
+    throw new InvalidOperationException("AzureAd section is missing from configuration");
+}
+
+AuthorizationBuilder authBuilder = builder.AddAuth();
 
 builder.Services.AddControllersWithViews();
 
@@ -31,7 +32,7 @@ builder.Services
 
 builder.Services.RegisterFeatureManagement();
 
-builder.AddUtilitiesModule();
+builder.AddUtilitiesModule(authBuilder);
 
 builder.Services
     .AddReverseProxy()

--- a/src/api/Menlo.Api/Utilities/UtilitiesModuleExtensions.cs
+++ b/src/api/Menlo.Api/Utilities/UtilitiesModuleExtensions.cs
@@ -4,9 +4,11 @@ namespace Menlo.Utilities;
 
 internal static class UtilitiesModuleExtensions
 {
-    internal static WebApplicationBuilder AddUtilitiesModule(this WebApplicationBuilder builder)
+    internal static WebApplicationBuilder AddUtilitiesModule(this WebApplicationBuilder builder, AuthorizationBuilder authorizationBuilder)
     {
         builder.Services.AddUtilitiesModule(builder.Configuration);
+
+        authorizationBuilder.AddUtilitiesPolicy();
 
         return builder;
     }


### PR DESCRIPTION
Fix the issue where the sing-in redirect is pointint to http, because Kestrel sees the current scheme as http when running in Docker in Azure. Since Azure provides the HTTPs certificate traffic will be HTTPs, but ASP.NET isn't aware.

To combat this, we now intercept the redirect URI and rewrite http:// to https://