### PR TITLE
fix: Average calc for elect usage

### DIFF
--- a/src/lib/Menlo.Lib/Utilities/Handlers/Electricity/ElectricityUsageQueryResponseBuilder.cs
+++ b/src/lib/Menlo.Lib/Utilities/Handlers/Electricity/ElectricityUsageQueryResponseBuilder.cs
@@ -11,7 +11,9 @@ public record class ElectricityUsageQueryResponseBuilder
 
     public ElectricityUsageQueryResponse Build()
     {
-        List<ApplianceUsageQueryResponse>? applianceUsageQueryResponses = CurrentUsageRecord.ApplianceUsages?.Select(ApplianceUsageQueryResponse.From).ToList() ?? [];
+        List<ApplianceUsageQueryResponse>? applianceUsageQueryResponses = CurrentUsageRecord.ApplianceUsages?
+            .Select(ApplianceUsageQueryResponse.From)
+            .ToList() ?? [];
 
         decimal previousUnits = PreviousUsageRecord?.Units ?? 0;
         decimal purchaseUnits = PurchaseRecord?.Units ?? 0;

--- a/src/ui/web/projects/menlo-app/src/app/dates/date-comparer.ts
+++ b/src/ui/web/projects/menlo-app/src/app/dates/date-comparer.ts
@@ -1,3 +1,0 @@
-export function compareDates(date1: string | Date, date2: string | Date): number {
-    return new Date(date1).getTime() - new Date(date2).getTime();
-}

--- a/src/ui/web/projects/menlo-app/src/app/dates/index.ts
+++ b/src/ui/web/projects/menlo-app/src/app/dates/index.ts
@@ -1,1 +1,0 @@
-export * from './date-comparer';

--- a/src/ui/web/projects/menlo-app/src/app/utilities/electricity/electricity-usage/electricity-usage.component.spec.ts
+++ b/src/ui/web/projects/menlo-app/src/app/utilities/electricity/electricity-usage/electricity-usage.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ElectricityUsageComponent } from './electricity-usage.component';
 import { SIGNAL, signalSetFn } from '@angular/core/primitives/signals';
+import { ElectricityUsage } from '@utilities/electricity/electricity-usage/electricity-usage.model';
 
 describe('ElectricityUsageComponent', () => {
     let component: ElectricityUsageComponent;
@@ -74,6 +75,27 @@ describe('ElectricityUsageComponent', () => {
         it('should not render the ag-grid-angular component', () => {
             const agGridElement = fixture.nativeElement.querySelector('ag-grid-angular');
             expect(agGridElement).toBeFalsy();
+        });
+    });
+
+    describe('chartData', () => {
+        it('should calculate the average based on the days between the first and last usage', () => {
+            const firstUsage = new ElectricityUsage();
+            firstUsage.date = '2024-10-17';
+            firstUsage.units = 544.8;
+            firstUsage.usage = 23.35;
+            firstUsage.applianceUsage = [];
+
+            const lastUsage = new ElectricityUsage();
+            lastUsage.date = '2024-10-21';
+            lastUsage.units = 490.65;
+            lastUsage.usage = 54.15;
+            lastUsage.applianceUsage = [];
+            signalSetFn(component.electricityUsage[SIGNAL], [firstUsage, lastUsage]);
+
+            const chartData = component.chartData();
+            const expectedAverage = (lastUsage.usage + firstUsage.usage) / 4;
+            expect(chartData.datasets[1].data).toEqual([expectedAverage, expectedAverage]);
         });
     });
 });

--- a/src/ui/web/projects/menlo-app/src/app/utilities/electricity/electricity-usage/electricity-usage.component.ts
+++ b/src/ui/web/projects/menlo-app/src/app/utilities/electricity/electricity-usage/electricity-usage.component.ts
@@ -3,7 +3,16 @@ import { AgGridAngular } from 'ag-grid-angular';
 import { ColDef } from 'ag-grid-community';
 import { ElectricityUsage } from './electricity-usage.model';
 import { DatePipe } from '@angular/common';
-import { ChartComponent, DateFormat, DateOrString, formatDate, LoadingComponent, MenloChartData, MenloChartLinearScale } from 'menlo-lib';
+import {
+    ChartComponent,
+    DateFormat,
+    DateOrString,
+    DateRangeService,
+    formatDate, getDateDiff,
+    LoadingComponent,
+    MenloChartData,
+    MenloChartLinearScale
+} from 'menlo-lib';
 
 @Component({
     selector: 'menlo-electricity-usage',
@@ -65,6 +74,7 @@ export class ElectricityUsageComponent {
 
     private getChartData(electricityUsage: ElectricityUsage[]): MenloChartData {
         const usages: number[] = electricityUsage.map(usage => usage.usage);
+        const days = electricityUsage.length > 0 ? getDateDiff(electricityUsage[0].date, electricityUsage[1].date) : 1;
 
         return {
             labels: electricityUsage.map(usage => formatDate(usage.date, DateFormat.ShortDisplay)),
@@ -77,7 +87,7 @@ export class ElectricityUsageComponent {
                 },
                 {
                     label: 'Average Usage',
-                    data: usages.map(() => usages.reduce((acc, val) => acc + val, 0) / usages.length),
+                    data: usages.map(() => usages.reduce((acc, val) => acc + val, 0) / days),
                     pointStyle: 'circle',
                     pointRadius: 5
                 }

--- a/src/ui/web/projects/menlo-lib/src/lib/types/date-or-string.type.spec.ts
+++ b/src/ui/web/projects/menlo-lib/src/lib/types/date-or-string.type.spec.ts
@@ -1,4 +1,4 @@
-import { DateOrString, formatDate } from './date-or-string.type';
+import { DateOrString, formatDate, getDateDiff } from './date-or-string.type';
 
 describe('DateOrString', () => {
     it('should allow a Date to be assinged', () => {
@@ -25,4 +25,69 @@ describe('formatDate', () => {
             expect(formatted).toEqual('2024-08-01');
         });
     }
+});
+
+describe('getDateDiff', () => {
+    it('should return the difference in days between two dates', () => {
+        const date1 = new Date(2024, 7, 1);
+        const date2 = new Date(2024, 7, 5);
+        const diff = getDateDiff(date1, date2);
+        expect(diff).toEqual(4);
+    });
+
+    it('should return the difference in months between two dates', () => {
+        const date1 = new Date(2024, 7, 1);
+        const date2 = new Date(2025, 9, 1);
+        const diff = getDateDiff(date1, date2, 'months');
+        expect(diff).toEqual(14);
+    });
+
+    it('should return the difference in years between two dates', () => {
+        const date1 = new Date(2024, 7, 1);
+        const date2 = new Date(2026, 7, 1);
+        const diff = getDateDiff(date1, date2, 'years');
+        expect(diff).toEqual(2);
+    });
+
+    it('should return the difference in days between two strings', () => {
+        const date1 = '2024-08-01';
+        const date2 = '2024-08-05';
+        const diff = getDateDiff(date1, date2);
+        expect(diff).toEqual(4);
+    });
+
+    it('should return the difference in months between two strings', () => {
+        const date1 = '2024-08-01';
+        const date2 = '2024-10-01';
+        const diff = getDateDiff(date1, date2, 'months');
+        expect(diff).toEqual(2);
+    });
+
+    it('should return the difference in years between two strings', () => {
+        const date1 = '2024-08-01';
+        const date2 = '2026-08-01';
+        const diff = getDateDiff(date1, date2, 'years');
+        expect(diff).toEqual(2);
+    });
+
+    it('should return the difference in days between a string and a Date', () => {
+        const date1 = '2024-08-01';
+        const date2 = new Date(2024, 7, 5);
+        const diff = getDateDiff(date1, date2);
+        expect(diff).toEqual(4);
+    });
+
+    it('should return the difference in months between a string and a Date', () => {
+        const date1 = '2024-08-01';
+        const date2 = new Date(2024, 9, 1);
+        const diff = getDateDiff(date1, date2, 'months');
+        expect(diff).toEqual(2);
+    });
+
+    it('should return the difference in years between a string and a Date', () => {
+        const date1 = '2024-08-01';
+        const date2 = new Date(2026, 7, 1);
+        const diff = getDateDiff(date1, date2, 'years');
+        expect(diff).toEqual(2);
+    });
 });

--- a/src/ui/web/projects/menlo-lib/src/lib/types/date-or-string.type.ts
+++ b/src/ui/web/projects/menlo-lib/src/lib/types/date-or-string.type.ts
@@ -1,3 +1,5 @@
+import { DateRangeFilterUnit } from '../common/date-range';
+
 export type DateOrString = Date | string;
 export const DateFormat = {
     DateOnly: 'DateOnly',
@@ -62,4 +64,32 @@ function buildDateString(input: Date | number, format: DateFormat, intlOptions: 
         case DateFormat.ShortDisplay:
             return `${dayPart?.value} ${monthPart?.value} ${yearPart?.value}`;
     }
+}
+
+export function getDateDiff(left: DateOrString, right: DateOrString, unit: DateRangeFilterUnit = 'days') {
+    const leftDate = new Date(left);
+    const rightDate = new Date(right);
+
+    let diff: number;
+    switch (unit) {
+        case 'years':
+            diff = leftDate.getFullYear() - rightDate.getFullYear();
+            break;
+        case 'months':
+            diff = (leftDate.getFullYear() - rightDate.getFullYear()) * 12 + leftDate.getMonth() - rightDate.getMonth();
+            break;
+        case 'days':
+            diff = (leftDate.getTime() - rightDate.getTime()) / (1000 * 60 * 60 * 24);
+            break;
+        case 'hours':
+            diff = (leftDate.getTime() - rightDate.getTime()) / (1000 * 60 * 60);
+            break;
+        case 'minutes':
+            diff = (leftDate.getTime() - rightDate.getTime()) / (1000 * 60);
+            break;
+        default:
+            throw new Error(`Unsupported unit: ${unit}`);
+    }
+
+    return Math.ceil(Math.abs(diff));
 }


### PR DESCRIPTION
For days where I cannot capture a reading, the usage spikes like crazy. To combat this, we change the average calc to look at the number of days and not just the spikes.