### PR TITLE
Modify uitlities endpoint group route

### DIFF
--- a/src/api/Menlo.Api/Utilities/UtilitiesEndpoints.cs
+++ b/src/api/Menlo.Api/Utilities/UtilitiesEndpoints.cs
@@ -12,7 +12,7 @@ public static partial class UtilitiesEndpoints
     public static void MapEndpoints(this IEndpointRouteBuilder routes)
     {
         routes.MapPost(
-                "/utilities/electricity/usage",
+                "/electricity/usage",
                 async (
                     ICommandHandler<CaptureElectricityUsageRequest, string> handler,
                     CaptureElectricityUsageRequest request,
@@ -28,7 +28,7 @@ public static partial class UtilitiesEndpoints
             .WithOpenApi();
 
         routes.MapPost(
-                "/utilities/electricity/purchase",
+                "/electricity/purchase",
                 async (
                     ICommandHandler<CaptureElectricityPurchaseRequest, string> handler,
                     CaptureElectricityPurchaseRequest request,
@@ -44,7 +44,7 @@ public static partial class UtilitiesEndpoints
             .WithOpenApi();
 
         routes.MapGet(
-                "/utilities/electricity",
+                "/electricity",
                 async (
                     IQueryHandler<ElectricityUsageQuery, IEnumerable<ElectricityUsageQueryResponse>> handler,
                     HttpRequest request,

--- a/src/api/Menlo.Api/Utilities/UtilitiesModuleExtensions.cs
+++ b/src/api/Menlo.Api/Utilities/UtilitiesModuleExtensions.cs
@@ -28,7 +28,7 @@ internal static class UtilitiesModuleExtensions
             return app;
         }
 
-        app.MapGroup("/api")
+        app.MapGroup("/api/utilities")
             .RequireAuthorizationWithBypass(app, AuthConstants.PolicyNameUtilities)
             .MapEndpoints();
 


### PR DESCRIPTION
The MapEndpoints extension no-longer requires each endpoint to add the utlities part of the route due to it being part of the main utlity module bootstrap.