### PR TITLE
Fix the inverted auth selection

### DIFF
--- a/src/api/Menlo.Api/Utilities/UtilitiesModuleExtensions.cs
+++ b/src/api/Menlo.Api/Utilities/UtilitiesModuleExtensions.cs
@@ -8,7 +8,7 @@ internal static class UtilitiesModuleExtensions
         this WebApplicationBuilder builder,
         AuthorizationBuilder authorizationBuilder)
     {
-        builder.Services.AddUtilitiesModule(builder.Configuration, builder.Environment.IsProduction());
+        builder.Services.AddUtilitiesModule(builder.Configuration, !builder.Environment.IsProduction());
 
         authorizationBuilder.AddUtilitiesPolicy();
 


### PR DESCRIPTION
For Cosmos auth, I messed up the logic for when to use VS over MI credentials. This fixes that.