### PR TITLE
fix: pipeline dotnet version

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
     - name: Restore local tools
       run: dotnet tool restore
     - name: Restore dependencies

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
       - name: Download menlo-app Artifact to wwwroot
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Cause I couldn't wait for the builds to complete, I clearly have to create a new commit to fix my stupidity.

This commit fixes the dotnet version in the GitHub Actions