### PR TITLE
Fix the docker image's dotnet version

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -108,7 +108,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            VERSION=8.0
+            VERSION=9.0
 
   deploy_infra:
     name: Deploy Azure Infra


### PR DESCRIPTION
I forgot to include the docker image as part of the dotnet version fixes for the pipelines