### PR TITLE
docs: Update persistence layer documentation and C4 diagrams

### DIFF
--- a/docs/diagrams/c4-component-diagram.md
+++ b/docs/diagrams/c4-component-diagram.md
@@ -85,6 +85,19 @@ graph TB
             NotificationService[📡 Notification Service<br/>SignalR Hub<br/>Real-time notifications<br/>across features]
             AuthenticationService[🔐 Authentication Service<br/>ASP.NET Identity<br/>JWT token validation<br/>and user management]
         end
+
+        %% Application Layer (Menlo.Application)
+        subgraph ApplicationLayer["📦 Menlo.Application"]
+            MenloDbContext[🗄️ MenloDbContext<br/>Single EF Core DbContext<br/>Implements all slice interfaces<br/>snake_case naming convention]
+            IBudgetContext[📋 IBudgetContext<br/>Slice interface for<br/>Budget bounded context]
+            IPlanningContext[📋 IPlanningContext<br/>Slice interface for<br/>Planning bounded context]
+            IFinancialContext[📋 IFinancialContext<br/>Slice interface for<br/>Financial bounded context]
+            IHouseholdContext[📋 IHouseholdContext<br/>Slice interface for<br/>Household bounded context]
+            IEventContext[📋 IEventContext<br/>Slice interface for<br/>Events bounded context]
+            IUserContext[📋 IUserContext<br/>Slice interface for<br/>Auth bounded context]
+            AuditingInterceptor[🔍 AuditingInterceptor<br/>Auto-populates audit fields<br/>on create/update]
+            SoftDeleteInterceptor[🗑️ SoftDeleteInterceptor<br/>Converts deletes to<br/>soft deletes transparently]
+        end
         
         %% Database
         Database[(🗃️ PostgreSQL Database<br/>Stores all application data<br/>with EF Core mapping)]
@@ -112,7 +125,7 @@ graph TB
     %% Feature Internal Flows (Budget)
     BudgetEndpoints --> BudgetHandlers
     BudgetHandlers --> BudgetModels
-    BudgetHandlers --> BudgetRepository
+    BudgetHandlers --> IBudgetContext
     BudgetHandlers --> BudgetAnalyser
     BudgetHandlers --> TransactionCategorizer
     BudgetHandlers --> RentalCostAnalyser
@@ -120,7 +133,7 @@ graph TB
     %% Feature Internal Flows (Planning)
     PlanningEndpoints --> PlanningHandlers
     PlanningHandlers --> PlanningModels
-    PlanningHandlers --> PlanningRepository
+    PlanningHandlers --> IPlanningContext
     PlanningHandlers --> ListInterpreter
     PlanningHandlers --> BudgetImpactAnalyser
     PlanningHandlers --> PantryOptimizer
@@ -129,7 +142,7 @@ graph TB
     %% Feature Internal Flows (Financial)
     FinancialEndpoints --> FinancialHandlers
     FinancialHandlers --> FinancialModels
-    FinancialHandlers --> FinancialRepository
+    FinancialHandlers --> IFinancialContext
     FinancialHandlers --> ImportProcessor
     FinancialHandlers --> DuplicateDetector
     FinancialHandlers --> AttributionSuggester
@@ -138,14 +151,14 @@ graph TB
     %% Feature Internal Flows (Household)
     HouseholdEndpoints --> HouseholdHandlers
     HouseholdHandlers --> HouseholdModels
-    HouseholdHandlers --> HouseholdRepository
+    HouseholdHandlers --> IHouseholdContext
     HouseholdHandlers --> UtilityOptimizer
     HouseholdHandlers --> RentalAttributionAnalyser
     
     %% Feature Internal Flows (Event)
     EventEndpoints --> EventHandlers
     EventHandlers --> EventModels
-    EventHandlers --> EventRepository
+    EventHandlers --> IEventContext
     EventHandlers --> SmartScheduler
     
     %% AI Orchestration
@@ -160,12 +173,18 @@ graph TB
     AICoordinator --> OllamaService
     AICoordinator --> LearningEngine
     
-    %% Repository to Database
-    BudgetRepository --> Database
-    PlanningRepository --> Database
-    FinancialRepository --> Database
-    HouseholdRepository --> Database
-    EventRepository --> Database
+    %% Slice Contexts to MenloDbContext
+    IBudgetContext --> MenloDbContext
+    IPlanningContext --> MenloDbContext
+    IFinancialContext --> MenloDbContext
+    IHouseholdContext --> MenloDbContext
+    IEventContext --> MenloDbContext
+    IUserContext --> MenloDbContext
+    
+    %% MenloDbContext to Database (with interceptors)
+    MenloDbContext --> AuditingInterceptor
+    MenloDbContext --> SoftDeleteInterceptor
+    MenloDbContext --> Database
     
     %% Shared Services
     BudgetHandlers --> NotificationService
@@ -179,12 +198,12 @@ graph TB
     ImportProcessor --> BankSystem
     NotificationService --> Pages
     
-    %% Cross-feature Dependencies
-    BudgetImpactAnalyser --> BudgetRepository
-    SmartScheduler --> BudgetRepository
-    TransactionCategorizer --> PlanningRepository
-    PantryOptimizer --> PlanningRepository
-    ShoppingListGenerator --> PlanningRepository
+    %% Cross-feature Dependencies (via slice context interfaces)
+    BudgetImpactAnalyser --> IBudgetContext
+    SmartScheduler --> IBudgetContext
+    TransactionCategorizer --> IPlanningContext
+    PantryOptimizer --> IPlanningContext
+    ShoppingListGenerator --> IPlanningContext
     
     %% Styling
     classDef azureClass fill:#e3f2fd,stroke:#1976d2,stroke-width:2px,color:#000
@@ -197,19 +216,21 @@ graph TB
     classDef eventClass fill:#e1f5fe,stroke:#0277bd,stroke-width:2px,color:#000
     classDef aiClass fill:#f1f8e9,stroke:#558b2f,stroke-width:2px,color:#000
     classDef sharedClass fill:#fafafa,stroke:#424242,stroke-width:2px,color:#000
+    classDef applicationClass fill:#ede7f6,stroke:#512da8,stroke-width:2px,color:#000
     classDef dbClass fill:#ffebee,stroke:#c62828,stroke-width:3px,color:#000
     classDef externalClass fill:#f5f5f5,stroke:#616161,stroke-width:2px,color:#000
     
     class Pages azureClass
     class CFTunnel cloudflareClass
     class APIHost apiClass
-    class BudgetEndpoints,BudgetHandlers,BudgetModels,BudgetRepository,BudgetAnalyser,TransactionCategorizer,RentalCostAnalyser budgetClass
-    class PlanningEndpoints,PlanningHandlers,PlanningModels,PlanningRepository,ListInterpreter,BudgetImpactAnalyser,PantryOptimizer,ShoppingListGenerator planningClass
-    class FinancialEndpoints,FinancialHandlers,FinancialModels,FinancialRepository,ImportProcessor,DuplicateDetector,AttributionSuggester,ReconciliationMatcher financialClass
-    class HouseholdEndpoints,HouseholdHandlers,HouseholdModels,HouseholdRepository,UtilityOptimizer,RentalAttributionAnalyser householdClass
-    class EventEndpoints,EventHandlers,EventModels,EventRepository,SmartScheduler eventClass
+    class BudgetEndpoints,BudgetHandlers,BudgetModels,BudgetAnalyser,TransactionCategorizer,RentalCostAnalyser budgetClass
+    class PlanningEndpoints,PlanningHandlers,PlanningModels,ListInterpreter,BudgetImpactAnalyser,PantryOptimizer,ShoppingListGenerator planningClass
+    class FinancialEndpoints,FinancialHandlers,FinancialModels,ImportProcessor,DuplicateDetector,AttributionSuggester,ReconciliationMatcher financialClass
+    class HouseholdEndpoints,HouseholdHandlers,HouseholdModels,UtilityOptimizer,RentalAttributionAnalyser householdClass
+    class EventEndpoints,EventHandlers,EventModels,SmartScheduler eventClass
     class SemanticKernel,AICoordinator,LearningEngine,OllamaService aiClass
     class NotificationService,AuthenticationService sharedClass
+    class MenloDbContext,IBudgetContext,IPlanningContext,IFinancialContext,IHouseholdContext,IEventContext,IUserContext,AuditingInterceptor,SoftDeleteInterceptor applicationClass
     class Database dbClass
     class FamilyDevices,BankSystem externalClass
 ```
@@ -230,8 +251,18 @@ Each feature (Budget, Planning, Financial, Household, Event) is organized as a v
 - **Endpoints**: Minimal API controllers
 - **Handlers**: Command/Query handlers for business logic
 - **Models**: Domain entities as C# records
-- **Repository**: EF Core data access
+- **Slice Context Interface**: Focused data access (e.g., `IBudgetContext`)
 - **AI Services**: Feature-specific AI capabilities
+
+### Menlo.Application - Persistence Layer
+
+The `Menlo.Application` project provides the unified data access layer:
+
+- **Single MenloDbContext**: Implements all slice context interfaces
+- **Slice Context Interfaces**: Per-bounded-context focused interfaces (e.g., `IUserContext`, `IBudgetContext`) enforcing domain boundary access control
+- **Interceptors**: `AuditingInterceptor` and `SoftDeleteInterceptor` transparently handle cross-cutting concerns
+- **EF Core Conventions**: snake_case naming, strongly typed ID value converters, UTC timestamps
+- **Global Query Filters**: Soft-deleted records automatically excluded from standard queries
 
 ### AI Integration
 

--- a/docs/explanations/architecture-document.md
+++ b/docs/explanations/architecture-document.md
@@ -458,7 +458,13 @@ src/
 │   │   ├── Financial/           # Financial domain
 │   │   ├── Events/              # Events domain
 │   │   ├── Household/           # Household domain
+│   │   ├── Auth/                # Authentication domain
 │   │   └── Common/              # Shared domain patterns
+│   ├── Menlo.Application/       # EF Core + persistence layer
+│   │   ├── Common/              # DbContext, interceptors, DI setup
+│   │   │   └── Interceptors/    # AuditingInterceptor, SoftDeleteInterceptor
+│   │   ├── Auth/                # IUserContext, User entity configuration
+│   │   └── Migrations/          # EF Core migrations
 │   ├── Menlo.AI/                # AI infrastructure layer
 │   └── Menlo.ServiceDefaults/   # Shared infrastructure
 └── ui/                          # Frontend application
@@ -466,6 +472,8 @@ src/
         ├── projects/menlo-app/  # Main application
         └── projects/menlo-lib/  # Shared UI components
 ```
+
+**Slice Context Interface Pattern**: Feature code does not inject `MenloDbContext` directly. Instead, each bounded context has a focused interface (e.g., `IUserContext`) exposing only its own `DbSet<T>` and `SaveChangesAsync()`. `MenloDbContext` implements all slice interfaces, ensuring shared change tracking while enforcing domain boundary access control at the type system level.
 
 ### Design Pattern Standards
 

--- a/docs/requirements/repo-structure/diagrams/repo-structure.md
+++ b/docs/requirements/repo-structure/diagrams/repo-structure.md
@@ -14,13 +14,19 @@ flowchart TD
   B2 --> B21[Menlo.Lib/]
   B2 --> B22[Menlo.AI/]
   B2 --> B23[Menlo.ServiceDefaults/]
+  B2 --> B24[Menlo.Application/]
+  B2 --> B25[Menlo.Lib.Tests/]
+  B2 --> B26[Menlo.AI.Tests/]
+  B2 --> B27[Menlo.Application.Tests/]
   B3 --> B31[web/]
 ```
 
 Notes:
 
-- Target framework: .NET 9 for all projects per architecture document.
+- Target framework: .NET 10 for all projects per architecture document.
 - Central package management via Directory.Packages.props.
 - API wired with ServiceDefaults and default health endpoints (development).
 - Aspire AppHost references Menlo.Api as a distributed resource.
+- `Menlo.Application` owns EF Core DbContext, migrations, interceptors, and slice context interfaces.
+- `Menlo.Application.Tests` contains persistence integration tests using TestContainers.
 - Initial API smoke test verifies startup and basic endpoint.

--- a/docs/requirements/repo-structure/implementation.md
+++ b/docs/requirements/repo-structure/implementation.md
@@ -49,8 +49,24 @@ dotnet sln add lib/Menlo.ServiceDefaults/Menlo.ServiceDefaults.csproj
 ```sh
 dotnet new classlib -n Menlo.Lib -o lib/Menlo.Lib
 dotnet new classlib -n Menlo.AI -o lib/Menlo.AI
+dotnet new classlib -n Menlo.Application -o lib/Menlo.Application
 dotnet sln add lib/Menlo.Lib/Menlo.Lib.csproj
 dotnet sln add lib/Menlo.AI/Menlo.AI.csproj
+dotnet sln add lib/Menlo.Application/Menlo.Application.csproj
+```
+
+Install EF Core packages to `Menlo.Application`:
+
+```sh
+dotnet add lib/Menlo.Application/Menlo.Application.csproj package Npgsql.EntityFrameworkCore.PostgreSQL
+dotnet add lib/Menlo.Application/Menlo.Application.csproj package EFCore.NamingConventions
+dotnet add lib/Menlo.Application/Menlo.Application.csproj package Microsoft.EntityFrameworkCore.Design
+```
+
+Add reference from `Menlo.Application` to `Menlo.Lib`:
+
+```sh
+dotnet add lib/Menlo.Application/Menlo.Application.csproj reference lib/Menlo.Lib/Menlo.Lib.csproj
 ```
 
 ### 4.4. Minimal API
@@ -66,6 +82,8 @@ dotnet sln add api/Menlo.Api/Menlo.Api.csproj
 # Menlo.Lib and Menlo.AI to Menlo.Api
 dotnet add api/Menlo.Api/Menlo.Api.csproj reference ../lib/Menlo.Lib/Menlo.Lib.csproj
 dotnet add api/Menlo.Api/Menlo.Api.csproj reference ../lib/Menlo.AI/Menlo.AI.csproj
+# Menlo.Application to Menlo.Api (persistence layer)
+dotnet add api/Menlo.Api/Menlo.Api.csproj reference ../lib/Menlo.Application/Menlo.Application.csproj
 # ServiceDefaults to Menlo.Api
 dotnet add api/Menlo.Api/Menlo.Api.csproj reference ../lib/Menlo.ServiceDefaults/Menlo.ServiceDefaults.csproj
 # Menlo.Api and ServiceDefaults to AppHost
@@ -95,13 +113,25 @@ dotnet add api/Menlo.AppHost/Menlo.AppHost.csproj reference ../lib/Menlo.Service
   builder.Build().Run();
   ```
 
-### 4.7. (Optional) EF Core Migrations
+### 4.7. EF Core Migrations
+
+EF Core tooling and packages are already configured in `Menlo.Application`. Install the EF CLI tool globally:
 
 ```sh
 dotnet tool install --global dotnet-ef
-dotnet add lib/Menlo.Lib/Menlo.Lib.csproj package Microsoft.EntityFrameworkCore
-dotnet add api/Menlo.Api/Menlo.Api.csproj package Microsoft.EntityFrameworkCore.Design
 ```
+
+Create and apply migrations from the repository root:
+
+```sh
+# Create a new migration
+dotnet ef migrations add <MigrationName> --project src/lib/Menlo.Application --startup-project src/api/Menlo.Api
+
+# Apply pending migrations
+dotnet ef database update --project src/lib/Menlo.Application --startup-project src/api/Menlo.Api
+```
+
+> ℹ️ **Note**: Migrations run automatically on API startup via `MigrateDatabaseAsync()`. Manual migration commands are typically only needed during development when adding new migrations.
 
 ## 5. Frontend (Angular)
 

--- a/docs/requirements/repo-structure/specifications.md
+++ b/docs/requirements/repo-structure/specifications.md
@@ -16,7 +16,11 @@ Define and enforce the directory layout, naming conventions, and architectural r
 - Backend APIs and related infrastructure must be placed under `src/api/`.
 - The Aspire AppHost must also be placed under `src/api/`.
 - Features are grouped by vertical slice (domain/feature), not by technical layer.
-- Shared libraries and infrastructure live under `lib/`.
+- Shared libraries and infrastructure live under `lib/`:
+  - `Menlo.Lib` contains domain models, abstractions, and business logic.
+  - `Menlo.Application` contains EF Core infrastructure, migrations, interceptors, and slice context interfaces.
+  - `Menlo.AI` contains AI service implementations.
+  - `Menlo.ServiceDefaults` contains Aspire service defaults.
 - UI implementations (e.g., web apps, mobile apps) are under `ui/`.
 - Each vertical slice contains its own domain models, handlers, endpoints, and tests.
 - Naming conventions and folder structure must follow the [Architecture Document](../../explanations/architecture-document.md#code-organization-structure).


### PR DESCRIPTION
## Description
Update documentation to reflect Menlo.Application as the EF Core + PostgreSQL persistence layer.

### Changes
- **specifications.md**: Add Menlo.Application to lib/ folder specification with description of its role (EF Core infrastructure, migrations, interceptors, slice context interfaces)
- **implementation.md**: Add Menlo.Application project creation steps, EF Core package installation, project references, and migration commands  
- **repo-structure.md**: Add Menlo.Application and Menlo.Application.Tests to the mermaid diagram, update .NET version to 10
- **architecture-document.md**: Expand Code Organization Structure to include Menlo.Application folder hierarchy and add note explaining the slice context interface pattern
- **c4-component-diagram.md**: Replace per-feature repository components with slice context interfaces (IBudgetContext, IPlanningContext, etc.), add ApplicationLayer subgraph showing MenloDbContext, interceptors, and slice interfaces, update styling

Resolves #248