### PR TITLE
feat(deployment): automated daily PostgreSQL backup service (NFR-004)

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -196,6 +196,55 @@ podman exec menlo-ollama ollama pull llava:latest
 
 Models are stored in the `ollama_data` volume and persist across container restarts.
 
+## 🗄️ Database Backup & Restore
+
+Automated daily backups are handled by the `db-backup` service using [`prodrigestivill/postgres-backup-local`](https://github.com/prodrigestivill/docker-postgres-backup-local). Backups are written to the `menlo_postgres_backups` volume and the last 7 daily backups are retained automatically.
+
+### Verify a Backup Ran
+
+```powershell
+# List backup files in the volume
+podman exec menlo-db-backup ls -lh /backups/daily/
+```
+
+You should see `.sql.gz` files named with a date (e.g., `menlo-20260417.sql.gz`) and a `menlo-latest.sql.gz` symlink pointing to the most recent one.
+
+### Restore from a Backup
+
+```powershell
+# Copy the latest backup out of the volume (or use a specific dated file)
+podman cp menlo-db-backup:/backups/last/menlo-latest.sql.gz .
+
+# Decompress
+gunzip menlo-latest.sql.gz
+
+# Stop the API first to avoid conflicts
+podman stop menlo-api
+
+# Restore into the running postgres container
+Get-Content menlo-latest.sql | podman exec -i menlo-postgres psql -U menlo -d menlo
+
+# Restart the API
+podman start menlo-api
+```
+
+> **Note:** To restore a specific point-in-time backup, replace `menlo-latest.sql.gz` with a timestamped file from `/backups/last/` (e.g., `menlo-20260417-020000.sql.gz`).
+
+### Configure Schedule and Retention
+
+Set these environment variables before bringing the stack up (e.g., in a `.env` file):
+
+| Variable | Default | Description |
+|---|---|---|
+| `BACKUP_SCHEDULE` | `@daily` | Cron expression or `@daily`/`@hourly` shorthand |
+| `BACKUP_KEEP_DAYS` | `7` | Number of daily backups to retain |
+
+Example `.env` override:
+```env
+BACKUP_SCHEDULE=0 2 * * *
+BACKUP_KEEP_DAYS=14
+```
+
 ## 🛠️ Troubleshooting
 
 ### Podman Issues

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -57,6 +57,28 @@ services:
       retries: 5
       start_period: 30s
 
+  db-backup:
+    image: prodrigestivill/postgres-backup-local:17
+    container_name: menlo-db-backup
+    restart: unless-stopped
+    environment:
+      - POSTGRES_HOST=postgres
+      - POSTGRES_DB=${POSTGRES_DB:-menlo}
+      - POSTGRES_USER=${POSTGRES_USER:-menlo}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - SCHEDULE=${BACKUP_SCHEDULE:-@daily}
+      - BACKUP_KEEP_DAYS=${BACKUP_KEEP_DAYS:-7}
+      - BACKUP_KEEP_WEEKS=0
+      - BACKUP_KEEP_MONTHS=0
+      - HEALTHCHECK_PORT=8080
+    volumes:
+      - postgres_backups:/backups
+    networks:
+      - menlo-network
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   ollama:
     image: ollama/ollama:latest
     container_name: menlo-ollama
@@ -113,6 +135,8 @@ networks:
 # - POSTGRES_USER: Database username (default: menlo)
 # - POSTGRES_PASSWORD: Database password (REQUIRED)
 # - POSTGRES_DB: Database name (default: menlo)
+# - BACKUP_SCHEDULE: Backup cron schedule (default: @daily)
+# - BACKUP_KEEP_DAYS: Number of daily backups to retain (default: 7)
 #
 # Model Management:
 # After first startup, download required models:

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -11,7 +11,7 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
       - ASPNETCORE_URLS=http://+:8080
-      - ConnectionStrings__menlo=Host=postgres;Database=${POSTGRES_DB:-menlo};Username=${POSTGRES_USER:-menlo};Password=${POSTGRES_PASSWORD}
+      - ConnectionStrings__menlo=Host=postgres;Database=${POSTGRES_DB:-menlo};Username=${POSTGRES_USER:-menlo};Password=${POSTGRES_PASSWORD};SSL Mode=Disable
       - Ollama__BaseUrl=http://ollama:11434
       - Logging__LogLevel__Default=Information
       - Logging__LogLevel__Microsoft.AspNetCore=Warning


### PR DESCRIPTION
## Summary

Implements automated daily PostgreSQL backups satisfying NFR-004 (RPO < 24 hours), resolving #249.

## Changes

- **\deployment/docker-compose.prod.yml\**: Add \db-backup\ service using \prodrigestivill/postgres-backup-local:17\
  - Connects to \postgres\ using the same credentials
  - Runs daily \pg_dump\ on a configurable schedule (default: \@daily\)
  - Writes compressed backups to the existing \postgres_backups\ volume
  - Retains the last 7 daily backups; older files are pruned automatically
  - \estart: unless-stopped\, depends on \postgres\ being healthy
  - Schedule and retention configurable via \BACKUP_SCHEDULE\ / \BACKUP_KEEP_DAYS\
- **\deployment/docker-compose.prod.yml\**: Add \SSL Mode=Disable\ to the API connection string — Npgsql defaults to requesting SSL which caused the API to crash on startup against an unencrypted postgres container on the same private network
- **\deployment/README.md\**: New *Database Backup & Restore* section covering backup verification, restore procedure, and env var configuration

## Verification

Tested against the live deployment — manual backup ran successfully, producing \menlo-20260417.sql.gz\ in \/backups/daily/\ inside the \menlo_postgres_backups\ volume.

## Closes

Closes #249