### PR TITLE
fix(deployment): add SSL Mode=Disable to CD-generated connection strings

### DIFF
--- a/.github/workflows/cd-backend.yml
+++ b/.github/workflows/cd-backend.yml
@@ -229,7 +229,7 @@ jobs:
               environment:
                 - ASPNETCORE_ENVIRONMENT=Production
                 - ASPNETCORE_URLS=http://+:8080
-                - ConnectionStrings__menlo=Host=postgres;Database=menlo;Username=$env:POSTGRES_USER;Password=$env:POSTGRES_PASSWORD
+                - ConnectionStrings__menlo=Host=postgres;Database=menlo;Username=$env:POSTGRES_USER;Password=$env:POSTGRES_PASSWORD;SSL Mode=Disable
                 - Ollama__BaseUrl=http://ollama:11434
                 - Logging__LogLevel__Default=Information
                 - AzureAd__Instance=$env:AZURE_AD_INSTANCE

--- a/deployment/deploy-windows.ps1
+++ b/deployment/deploy-windows.ps1
@@ -49,7 +49,7 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
       - ASPNETCORE_URLS=http://+:8080
-      - ConnectionStrings__menlo=Host=postgres;Database=$env:POSTGRES_DB;Username=$env:POSTGRES_USER;Password=$env:POSTGRES_PASSWORD
+      - ConnectionStrings__menlo=Host=postgres;Database=$env:POSTGRES_DB;Username=$env:POSTGRES_USER;Password=$env:POSTGRES_PASSWORD;SSL Mode=Disable
       - Ollama__BaseUrl=http://ollama:11434
       - Logging__LogLevel__Default=Information
     ports:


### PR DESCRIPTION
The previous fix (10d6e50) added SSL Mode=Disable to the template docker-compose.prod.yml, but the CD workflow and deploy-windows.ps1 generate their own compose files dynamically without this setting. Both files updated to include ;SSL Mode=Disable in the connection string. Validated locally: API starts cleanly, migrations run, health check returns 200 OK.