### PR TITLE
chore(ci): unify GitHub environments from prod to Production

### DIFF
--- a/.github/workflows/cd-backend.yml
+++ b/.github/workflows/cd-backend.yml
@@ -40,7 +40,7 @@ jobs:
       contains(github.event.head_commit.modified, 'infra/')
     uses: ./.github/workflows/cd-infra.yml
     with:
-      environment: prod
+      environment: Production
     secrets: inherit
 
     permissions:

--- a/.github/workflows/cd-infra.yml
+++ b/.github/workflows/cd-infra.yml
@@ -6,17 +6,17 @@ on:
       environment:
         description: 'Environment to deploy'
         required: true
-        default: 'prod'
+        default: 'Production'
         type: choice
         options:
-          - prod
+          - Production
           - dev
   workflow_call:
     inputs:
       environment:
         description: 'Environment to deploy'
         required: true
-        default: 'prod'
+        default: 'Production'
         type: string
     outputs:
       key-vault-name:
@@ -34,7 +34,7 @@ jobs:
   deploy-infrastructure:
     name: Deploy Azure Infrastructure
     runs-on: ubuntu-latest
-    environment: prod
+    environment: ${{ inputs.environment }}
 
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary

Consolidates duplicate GitHub environments by renaming all `prod` references to `Production`.

### Changes
- **cd-backend.yml**: Changed reusable workflow call environment from `prod` to `Production`
- **cd-infra.yml**: Updated workflow_dispatch/workflow_call defaults and options from `prod` to `Production`
- **cd-infra.yml**: Job environment now uses the input parameter instead of hardcoded `prod`

### Follow-up
After merging, delete the `prod` environment from **Settings > Environments** -- all workflows now target `Production`.