### PR TITLE
fix(auth): use AddMicrosoftIdentityWebApp for certificate client assertion

### DIFF
--- a/src/api/Menlo.Api.Tests/TestWebApplicationFactory.cs
+++ b/src/api/Menlo.Api.Tests/TestWebApplicationFactory.cs
@@ -192,7 +192,8 @@ public class TestWebApplicationFactory : WebApplicationFactory<Program>
             ["AzureAd:Instance"] = "https://login.microsoftonline.com/",
             ["AzureAd:TenantId"] = "test-tenant-id",
             ["AzureAd:ClientId"] = "test-client-id",
-            ["AzureAd:ClientSecret"] = "test-client-secret"
+            ["AzureAd:ClientSecret"] = "test-client-secret",
+            ["AzureAd:ResponseType"] = "code"
         };
 
         if (MenloConnectionString is not null)

--- a/src/api/Menlo.Api.Tests/packages.lock.json
+++ b/src/api/Menlo.Api.Tests/packages.lock.json
@@ -842,8 +842,8 @@
       },
       "Microsoft.SemanticKernel.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.76.0",
-        "contentHash": "pDLBE+iyZJvPiBXM4KbDCrdEHfPmz8FcjH7Rs0XrIJ6hdyHZFKZEQBfu45nWZ72womQsZxWe9vLrWV0TGAs6aQ==",
+        "resolved": "1.77.0",
+        "contentHash": "8aobJHE0hI01iVh+gJvCuqC9Ygjf+B5xeLefScUp0Y5xfWbvNfQpmsxuihG7Xyg2RFXQHOpC0lYe/qw8wMbOrA==",
         "dependencies": {
           "Microsoft.Bcl.HashCode": "1.1.1",
           "Microsoft.Extensions.AI": "10.5.0",
@@ -852,31 +852,31 @@
       },
       "Microsoft.SemanticKernel.Connectors.AzureOpenAI": {
         "type": "Transitive",
-        "resolved": "1.76.0",
-        "contentHash": "JAgUHpMmErsWjqPI8odOhFDBF6BsSP/oy/IcMQkDqQJw9Geyti+A8CbkA7FtY66Ks4VOEVFM6/qnAb6RvoorzQ==",
+        "resolved": "1.77.0",
+        "contentHash": "or5jro29W9/Jgq9iJ5FqyIzBUBjnUs2Somw52qToWfbNrS0Mb3c764sOyNmBxflZG9fVzW8SChCSsvFXuZJU5Q==",
         "dependencies": {
           "Azure.AI.OpenAI": "2.9.0-beta.1",
-          "Microsoft.SemanticKernel.Connectors.OpenAI": "1.76.0",
-          "Microsoft.SemanticKernel.Core": "1.76.0"
+          "Microsoft.SemanticKernel.Connectors.OpenAI": "1.77.0",
+          "Microsoft.SemanticKernel.Core": "1.77.0"
         }
       },
       "Microsoft.SemanticKernel.Connectors.OpenAI": {
         "type": "Transitive",
-        "resolved": "1.76.0",
-        "contentHash": "sVIiaYdjwg/J97y+8ZlwxMHHThOPZxqYNGOVuIF23P1yLxZYFLpKqHTVcPyyQrwo1soYT5uQqi0DddoLML/9vg==",
+        "resolved": "1.77.0",
+        "contentHash": "HZKfJ0+gUIRm91KElKvZIUtGH+ezUx0Y3YZnZGUvSdeIHhE65Bse1RMP2d2F4YqxiPBQT9/95Tb8aSPRFFu7Aw==",
         "dependencies": {
           "Microsoft.Extensions.AI.OpenAI": "10.5.0",
-          "Microsoft.SemanticKernel.Core": "1.76.0",
+          "Microsoft.SemanticKernel.Core": "1.77.0",
           "OpenAI": "2.10.0"
         }
       },
       "Microsoft.SemanticKernel.Core": {
         "type": "Transitive",
-        "resolved": "1.76.0",
-        "contentHash": "sqvVbsFjkQir7QuxpZHzp4lQ/ZXsPgbsYHfruPJnepie2yuJtqcPVty8d9MdCxq5XgCMZlvH3YzUuSihg1RQCA==",
+        "resolved": "1.77.0",
+        "contentHash": "o02MBl/gg+f5qbFzuFNcEfkj8RovXF9vwvGhmPAwpxBMHmMaiW4zkbPit2fwSNFgsekbHB4T+u9bochJx6/mYQ==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "10.0.2",
-          "Microsoft.SemanticKernel.Abstractions": "1.76.0",
+          "Microsoft.SemanticKernel.Abstractions": "1.77.0",
           "System.Numerics.Tensors": "10.0.6"
         }
       },
@@ -936,8 +936,8 @@
       },
       "Npgsql": {
         "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "q5RfBI+wywJSFUNDE1L4ZbHEHCFTblo8Uf6A6oe4feOUFYiUQXyAf9GBh5qEZpvJaHiEbpBPkQumjEhXCJxdrg==",
+        "resolved": "10.0.3",
+        "contentHash": "7nb5YzXuvWWJxB0J8DiyL3we+X4FOctZrt0fIBnucOIaIevFEEwGQVZKtiu9olXdlNAK1eNgqSral6r/jlhI4w==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
         }
@@ -1180,7 +1180,7 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.0.8, )",
-          "Microsoft.SemanticKernel": "[1.76.0, )",
+          "Microsoft.SemanticKernel": "[1.77.0, )",
           "Microsoft.SemanticKernel.Connectors.Ollama": "[1.76.0-alpha, )",
           "OpenTelemetry.Api": "[1.15.3, )"
         }
@@ -1208,7 +1208,7 @@
           "EFCore.NamingConventions": "[10.0.1, )",
           "Menlo.Lib": "[1.0.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.8, )",
-          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )"
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )"
         }
       },
       "menlo.lib": {
@@ -1411,12 +1411,12 @@
       },
       "Microsoft.SemanticKernel": {
         "type": "CentralTransitive",
-        "requested": "[1.76.0, )",
-        "resolved": "1.76.0",
-        "contentHash": "hvsteKZo86gK2diJVLOE70CGwcv38BvkW0EVEdcw1/XNA0u3LcG95txiqOSRV001hyZJrEWlRAmEScoA9JAdLQ==",
+        "requested": "[1.77.0, )",
+        "resolved": "1.77.0",
+        "contentHash": "A8HtEy+gKpOFPPS/IiJAcFIHbP0l6qAMKtg9bxw6cJJMUasWhLyU0weKi6FaL3V5lLuqU+sI0dEtD9fFnoBPpg==",
         "dependencies": {
-          "Microsoft.SemanticKernel.Connectors.AzureOpenAI": "1.76.0",
-          "Microsoft.SemanticKernel.Core": "1.76.0"
+          "Microsoft.SemanticKernel.Connectors.AzureOpenAI": "1.77.0",
+          "Microsoft.SemanticKernel.Core": "1.77.0"
         }
       },
       "Microsoft.SemanticKernel.Connectors.Ollama": {
@@ -1439,13 +1439,13 @@
       },
       "Npgsql.EntityFrameworkCore.PostgreSQL": {
         "type": "CentralTransitive",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "P6EwH0Q4xkaA264iNZDqCPhWt8pscfUGxXazDQg4noBfqjoOlk4hKWfvBjF9ZX3R/9JybRmmJfmxr2iBMj0EpA==",
+        "requested": "[10.0.2, )",
+        "resolved": "10.0.2",
+        "contentHash": "PsNYgPOSW41Xx19gin7y4EdZAPteWr9Cb01XkdObxOsPzi+mgBupBEN7J7+erXFsROPOILM7MlIoO9QzL8+LGQ==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "[10.0.4, 11.0.0)",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.4, 11.0.0)",
-          "Npgsql": "10.0.2"
+          "Npgsql": "10.0.3"
         }
       },
       "OpenTelemetry.Api": {

--- a/src/api/Menlo.Api/Auth/AuthServiceCollectionExtensions.cs
+++ b/src/api/Menlo.Api/Auth/AuthServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Menlo.Lib.Common.Abstractions;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.Options;
+using Microsoft.Identity.Web;
 
 namespace Menlo.Api.Auth;
 
@@ -32,81 +33,119 @@ public static class AuthServiceCollectionExtensions
             sp => sp.GetRequiredService<CurrentUserPersistenceStampFactory>());
 
         IConfigurationSection section = builder.Configuration.GetSection(MenloAuthOptions.SectionName);
-        MenloAuthOptions authOptions = section
-            .Get<MenloAuthOptions>()
-            ?? throw new InvalidOperationException("MenloAuthOptions configuration is missing.");
+        if (section.Get<MenloAuthOptions>() is null)
+        {
+            throw new InvalidOperationException("MenloAuthOptions configuration is missing.");
+        }
 
-        // Configure authentication with dual schemes (Cookie + OIDC)
+        // AddMicrosoftIdentityWebApp reads ClientCertificates (or ClientSecret) from the AzureAd
+        // config section and uses MSAL for the authorization code exchange. When ClientCertificates
+        // is configured (as injected by CD from Key Vault), MSAL generates the required
+        // client_assertion JWT — satisfying Entra ID's AADSTS7000218 requirement without a
+        // plain-text client_secret.
         builder.Services
             .AddAuthentication(options =>
             {
                 options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                 options.DefaultChallengeScheme = OpenIdConnectDefaults.AuthenticationScheme;
             })
-            .AddCookie(options =>
-            {
-                options.Cookie.Name = ".Menlo.Session";
-                options.Cookie.HttpOnly = true;
-                options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
-                options.Cookie.SameSite = SameSiteMode.Strict;
-                options.ExpireTimeSpan = TimeSpan.FromHours(8);
-                options.SlidingExpiration = true;
-                options.Events.OnRedirectToLogin = context =>
-                {
-                    // Return 401 for XHR/fetch calls (API and auth endpoints accessed programmatically)
-                    // rather than redirect to OIDC login, which would overwrite the session cookie
-                    if (IsXhrRequest(context.Request))
-                    {
-                        context.Response.StatusCode = StatusCodes.Status401Unauthorized;
-                        return Task.CompletedTask;
-                    }
+            .AddMicrosoftIdentityWebApp(section);
 
-                    context.Response.Redirect(context.RedirectUri);
-                    return Task.CompletedTask;
-                };
-            })
-            .AddOpenIdConnect(options =>
-            {
-                options.Authority = $"{authOptions.Instance}{authOptions.TenantId}/v2.0";
-                options.ClientId = authOptions.ClientId;
-                options.ClientSecret = authOptions.ClientSecret;
-                options.ResponseType = "code";
-                options.SaveTokens = true;
-                options.GetClaimsFromUserInfoEndpoint = true;
-                options.Scope.Add("openid");
-                options.Scope.Add("profile");
-                options.Scope.Add("email");
-                options.CallbackPath = authOptions.CallbackPath;
-                options.SignedOutCallbackPath = authOptions.SignedOutCallbackPath;
-                // Return 401 instead of redirecting to AAD for programmatic/XHR requests
-                // so Angular can handle auth state gracefully without OIDC overwriting the session cookie.
-                options.Events.OnRedirectToIdentityProvider = context =>
-                {
-                    if (IsXhrRequest(context.Request))
-                    {
-                        context.Response.StatusCode = StatusCodes.Status401Unauthorized;
-                        context.HandleResponse();
-                        return Task.CompletedTask;
-                    }
+        // PostConfigure runs after AddMicrosoftIdentityWebApp's internal OidcConfigurator,
+        // allowing us to layer Menlo-specific behaviour on top without losing MiW's
+        // certificate-based token acquisition logic.
+        builder.Services.PostConfigure<OpenIdConnectOptions>(
+            OpenIdConnectDefaults.AuthenticationScheme,
+            ConfigureOidcOptions);
 
-                    // Safety net: rewrite redirect URI scheme when running behind a TLS-terminating
-                    // reverse proxy (e.g. Cloudflare Tunnel) in case ForwardedHeaders middleware
-                    // did not process X-Forwarded-Proto.
-                    if (context.ProtocolMessage.RedirectUri?.StartsWith("http://", StringComparison.OrdinalIgnoreCase) == true)
-                    {
-                        context.ProtocolMessage.RedirectUri =
-                            string.Concat("https://", context.ProtocolMessage.RedirectUri.AsSpan(7));
-                    }
-
-                    return Task.CompletedTask;
-                };
-            });
+        builder.Services.PostConfigure<CookieAuthenticationOptions>(
+            CookieAuthenticationDefaults.AuthenticationScheme,
+            ConfigureCookieOptions);
 
         builder.Services
             .AddAuthorizationBuilder()
             .AddMenloPolicies();
 
         return builder;
+    }
+
+    private static void ConfigureOidcOptions(OpenIdConnectOptions options)
+    {
+        options.SaveTokens = true;
+        options.GetClaimsFromUserInfoEndpoint = true;
+
+        if (!options.Scope.Contains("email"))
+        {
+            options.Scope.Add("email");
+        }
+
+        // Wrap the existing OnRedirectToIdentityProvider (set by AddMicrosoftIdentityWebApp's
+        // OidcConfigurator) so both MiW logic and Menlo-specific behaviour run.
+        Func<RedirectContext, Task> existingRedirect = options.Events.OnRedirectToIdentityProvider;
+        options.Events.OnRedirectToIdentityProvider = async context =>
+        {
+            await existingRedirect(context);
+
+            if (context.Handled)
+            {
+                return;
+            }
+
+            // Return 401 for XHR/fetch requests so Angular handles auth state gracefully
+            // instead of receiving an unexpected redirect to Entra ID.
+            if (IsXhrRequest(context.Request))
+            {
+                context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                context.HandleResponse();
+                return;
+            }
+
+            // Safety net: rewrite redirect URI scheme when running behind a TLS-terminating
+            // reverse proxy (e.g. Cloudflare Tunnel) in case ForwardedHeaders middleware
+            // did not process X-Forwarded-Proto.
+            if (context.ProtocolMessage.RedirectUri?.StartsWith("http://", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                context.ProtocolMessage.RedirectUri =
+                    string.Concat("https://", context.ProtocolMessage.RedirectUri.AsSpan(7));
+            }
+        };
+
+        options.Events.OnRemoteFailure = context =>
+        {
+            ILogger logger = context.HttpContext.RequestServices
+                .GetRequiredService<ILoggerFactory>()
+                .CreateLogger(typeof(AuthServiceCollectionExtensions).FullName!);
+
+            logger.LogError(context.Failure, "OIDC authentication failed: {Error}", context.Failure?.Message);
+
+            context.Response.Redirect("/sign-in?error=auth_failed");
+            context.HandleResponse();
+            return Task.CompletedTask;
+        };
+    }
+
+    private static void ConfigureCookieOptions(CookieAuthenticationOptions options)
+    {
+        options.Cookie.Name = ".Menlo.Session";
+        options.Cookie.HttpOnly = true;
+        options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+        options.Cookie.SameSite = SameSiteMode.Strict;
+        options.ExpireTimeSpan = TimeSpan.FromHours(8);
+        options.SlidingExpiration = true;
+
+        options.Events.OnRedirectToLogin = context =>
+        {
+            // Return 401 for XHR/fetch calls (API and auth endpoints accessed programmatically)
+            // rather than redirect to OIDC login, which would overwrite the session cookie.
+            if (IsXhrRequest(context.Request))
+            {
+                context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                return Task.CompletedTask;
+            }
+
+            context.Response.Redirect(context.RedirectUri);
+            return Task.CompletedTask;
+        };
     }
 
     private static bool IsXhrRequest(HttpRequest request) =>

--- a/src/api/Menlo.Api/appsettings.json
+++ b/src/api/Menlo.Api/appsettings.json
@@ -5,7 +5,8 @@
     "Domain": "",
     "TenantId": "",
     "ClientId": "",
-    "ClientSecret": ""
+    "ClientSecret": "",
+    "ResponseType": "code"
   },
   "Logging": {
     "LogLevel": {

--- a/src/api/Menlo.Api/packages.lock.json
+++ b/src/api/Menlo.Api/packages.lock.json
@@ -479,8 +479,8 @@
       },
       "Microsoft.SemanticKernel.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.76.0",
-        "contentHash": "pDLBE+iyZJvPiBXM4KbDCrdEHfPmz8FcjH7Rs0XrIJ6hdyHZFKZEQBfu45nWZ72womQsZxWe9vLrWV0TGAs6aQ==",
+        "resolved": "1.77.0",
+        "contentHash": "8aobJHE0hI01iVh+gJvCuqC9Ygjf+B5xeLefScUp0Y5xfWbvNfQpmsxuihG7Xyg2RFXQHOpC0lYe/qw8wMbOrA==",
         "dependencies": {
           "Microsoft.Bcl.HashCode": "1.1.1",
           "Microsoft.Extensions.AI": "10.5.0",
@@ -489,30 +489,30 @@
       },
       "Microsoft.SemanticKernel.Connectors.AzureOpenAI": {
         "type": "Transitive",
-        "resolved": "1.76.0",
-        "contentHash": "JAgUHpMmErsWjqPI8odOhFDBF6BsSP/oy/IcMQkDqQJw9Geyti+A8CbkA7FtY66Ks4VOEVFM6/qnAb6RvoorzQ==",
+        "resolved": "1.77.0",
+        "contentHash": "or5jro29W9/Jgq9iJ5FqyIzBUBjnUs2Somw52qToWfbNrS0Mb3c764sOyNmBxflZG9fVzW8SChCSsvFXuZJU5Q==",
         "dependencies": {
           "Azure.AI.OpenAI": "2.9.0-beta.1",
-          "Microsoft.SemanticKernel.Connectors.OpenAI": "1.76.0",
-          "Microsoft.SemanticKernel.Core": "1.76.0"
+          "Microsoft.SemanticKernel.Connectors.OpenAI": "1.77.0",
+          "Microsoft.SemanticKernel.Core": "1.77.0"
         }
       },
       "Microsoft.SemanticKernel.Connectors.OpenAI": {
         "type": "Transitive",
-        "resolved": "1.76.0",
-        "contentHash": "sVIiaYdjwg/J97y+8ZlwxMHHThOPZxqYNGOVuIF23P1yLxZYFLpKqHTVcPyyQrwo1soYT5uQqi0DddoLML/9vg==",
+        "resolved": "1.77.0",
+        "contentHash": "HZKfJ0+gUIRm91KElKvZIUtGH+ezUx0Y3YZnZGUvSdeIHhE65Bse1RMP2d2F4YqxiPBQT9/95Tb8aSPRFFu7Aw==",
         "dependencies": {
           "Microsoft.Extensions.AI.OpenAI": "10.5.0",
-          "Microsoft.SemanticKernel.Core": "1.76.0",
+          "Microsoft.SemanticKernel.Core": "1.77.0",
           "OpenAI": "2.10.0"
         }
       },
       "Microsoft.SemanticKernel.Core": {
         "type": "Transitive",
-        "resolved": "1.76.0",
-        "contentHash": "sqvVbsFjkQir7QuxpZHzp4lQ/ZXsPgbsYHfruPJnepie2yuJtqcPVty8d9MdCxq5XgCMZlvH3YzUuSihg1RQCA==",
+        "resolved": "1.77.0",
+        "contentHash": "o02MBl/gg+f5qbFzuFNcEfkj8RovXF9vwvGhmPAwpxBMHmMaiW4zkbPit2fwSNFgsekbHB4T+u9bochJx6/mYQ==",
         "dependencies": {
-          "Microsoft.SemanticKernel.Abstractions": "1.76.0",
+          "Microsoft.SemanticKernel.Abstractions": "1.77.0",
           "System.Numerics.Tensors": "10.0.6"
         }
       },
@@ -536,8 +536,8 @@
       },
       "Npgsql": {
         "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "q5RfBI+wywJSFUNDE1L4ZbHEHCFTblo8Uf6A6oe4feOUFYiUQXyAf9GBh5qEZpvJaHiEbpBPkQumjEhXCJxdrg=="
+        "resolved": "10.0.3",
+        "contentHash": "7nb5YzXuvWWJxB0J8DiyL3we+X4FOctZrt0fIBnucOIaIevFEEwGQVZKtiu9olXdlNAK1eNgqSral6r/jlhI4w=="
       },
       "OllamaSharp": {
         "type": "Transitive",
@@ -693,7 +693,7 @@
           "CommunityToolkit.Aspire.OllamaSharp": "[13.3.0, )",
           "Menlo.Lib": "[1.0.0, )",
           "Microsoft.Extensions.AI": "[10.6.0, )",
-          "Microsoft.SemanticKernel": "[1.76.0, )",
+          "Microsoft.SemanticKernel": "[1.77.0, )",
           "Microsoft.SemanticKernel.Connectors.Ollama": "[1.76.0-alpha, )",
           "OpenTelemetry.Api": "[1.15.3, )"
         }
@@ -704,7 +704,7 @@
           "EFCore.NamingConventions": "[10.0.1, )",
           "Menlo.Lib": "[1.0.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.8, )",
-          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )"
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )"
         }
       },
       "menlo.lib": {
@@ -781,12 +781,12 @@
       },
       "Microsoft.SemanticKernel": {
         "type": "CentralTransitive",
-        "requested": "[1.76.0, )",
-        "resolved": "1.76.0",
-        "contentHash": "hvsteKZo86gK2diJVLOE70CGwcv38BvkW0EVEdcw1/XNA0u3LcG95txiqOSRV001hyZJrEWlRAmEScoA9JAdLQ==",
+        "requested": "[1.77.0, )",
+        "resolved": "1.77.0",
+        "contentHash": "A8HtEy+gKpOFPPS/IiJAcFIHbP0l6qAMKtg9bxw6cJJMUasWhLyU0weKi6FaL3V5lLuqU+sI0dEtD9fFnoBPpg==",
         "dependencies": {
-          "Microsoft.SemanticKernel.Connectors.AzureOpenAI": "1.76.0",
-          "Microsoft.SemanticKernel.Core": "1.76.0"
+          "Microsoft.SemanticKernel.Connectors.AzureOpenAI": "1.77.0",
+          "Microsoft.SemanticKernel.Core": "1.77.0"
         }
       },
       "Microsoft.SemanticKernel.Connectors.Ollama": {
@@ -803,13 +803,13 @@
       },
       "Npgsql.EntityFrameworkCore.PostgreSQL": {
         "type": "CentralTransitive",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "P6EwH0Q4xkaA264iNZDqCPhWt8pscfUGxXazDQg4noBfqjoOlk4hKWfvBjF9ZX3R/9JybRmmJfmxr2iBMj0EpA==",
+        "requested": "[10.0.2, )",
+        "resolved": "10.0.2",
+        "contentHash": "PsNYgPOSW41Xx19gin7y4EdZAPteWr9Cb01XkdObxOsPzi+mgBupBEN7J7+erXFsROPOILM7MlIoO9QzL8+LGQ==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "[10.0.4, 11.0.0)",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.4, 11.0.0)",
-          "Npgsql": "10.0.2"
+          "Npgsql": "10.0.3"
         }
       },
       "OpenTelemetry.Api": {


### PR DESCRIPTION
## Summary

Fixes #351

The production login was failing with AADSTS7000218 because the OIDC handler was configured with AddOpenIdConnect() which only supports ClientSecret. The CD pipeline correctly injects an X.509 certificate from Azure Key Vault as AzureAd__ClientCertificates__0__*, but the raw OIDC handler has no awareness of ClientCertificates — so it sent requests to Entra ID with no credential at all.

## Root Cause

- AddOpenIdConnect() only reads options.ClientSecret for token endpoint auth
- ClientCertificates config was validated and accepted by MenloAuthOptionsValidator but never consumed
- Result: Entra ID rejects the authorization code exchange with AADSTS7000218

## Fix

- Replace AddOpenIdConnect() with AddMicrosoftIdentityWebApp(section) which uses MSAL internally
- When ClientCertificates is configured, MSAL generates a signed client_assertion JWT (satisfying AADSTS7000218)
- Add ResponseType: code to ppsettings.json so MiW's OidcConfigurator wires up authorization code flow with PKCE
- Custom OIDC behaviour (XHR 401, HTTPS redirect rewrite, OnRemoteFailure handler) preserved via PostConfigure<OpenIdConnectOptions> — registered after MiW's internal OidcConfigurator, safely wrapping its event handlers
- Tests: fall back to ClientSecret (no certs in test env) — MSAL handles both transparently

## Test

All 205 existing tests pass. No new tests required — existing AuthServiceCollectionExtensionsTests already cover OIDC options, cookie settings and XHR behaviour.