### PR TITLE
fix(auth): enable MSAL token acquisition for certificate code exchange

### DIFF
--- a/src/api/Menlo.Api/Auth/AuthServiceCollectionExtensions.cs
+++ b/src/api/Menlo.Api/Auth/AuthServiceCollectionExtensions.cs
@@ -39,17 +39,21 @@ public static class AuthServiceCollectionExtensions
         }
 
         // AddMicrosoftIdentityWebApp reads ClientCertificates (or ClientSecret) from the AzureAd
-        // config section and uses MSAL for the authorization code exchange. When ClientCertificates
-        // is configured (as injected by CD from Key Vault), MSAL generates the required
-        // client_assertion JWT — satisfying Entra ID's AADSTS7000218 requirement without a
-        // plain-text client_secret.
+        // config section. EnableTokenAcquisitionToCallDownstreamApi() is the critical step:
+        // it registers MSAL and overrides OnAuthorizationCodeReceived so that MSAL — not the
+        // native OpenIdConnectHandler — exchanges the authorization code at the token endpoint.
+        // When ClientCertificates is configured (injected by CD from Key Vault), MSAL generates
+        // the required client_assertion JWT instead of sending a plain-text client_secret,
+        // satisfying Entra ID's AADSTS7000218 requirement.
         builder.Services
             .AddAuthentication(options =>
             {
                 options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                 options.DefaultChallengeScheme = OpenIdConnectDefaults.AuthenticationScheme;
             })
-            .AddMicrosoftIdentityWebApp(section);
+            .AddMicrosoftIdentityWebApp(section)
+            .EnableTokenAcquisitionToCallDownstreamApi()
+            .AddInMemoryTokenCaches();
 
         // PostConfigure runs after AddMicrosoftIdentityWebApp's internal OidcConfigurator,
         // allowing us to layer Menlo-specific behaviour on top without losing MiW's


### PR DESCRIPTION
## Summary

Fixes #351 (follow-up to #352)

## Root Cause (Corrected)

PR #352 switched to \AddMicrosoftIdentityWebApp\ but was still failing with AADSTS7000218. Investigation of the MiW 4.x source revealed the critical missing piece:

**\AddMicrosoftIdentityWebApp\ alone does NOT intercept \OnAuthorizationCodeReceived\.**

Without \EnableTokenAcquisitionToCallDownstreamApi()\, the native \OpenIdConnectHandler.RedeemAuthorizationCodeAsync\ still handles the authorization code exchange — and it only knows how to send \client_secret\ (which is null in production). MSAL is only wired into the code exchange event when you explicitly chain \EnableTokenAcquisitionToCallDownstreamApi()\.

## Fix

Chain \.EnableTokenAcquisitionToCallDownstreamApi().AddInMemoryTokenCaches()\ onto \AddMicrosoftIdentityWebApp\:

\\\csharp
.AddMicrosoftIdentityWebApp(section)
.EnableTokenAcquisitionToCallDownstreamApi()   // hooks MSAL into OnAuthorizationCodeReceived
.AddInMemoryTokenCaches();
\\\

This causes MSAL to:
1. Intercept \OnAuthorizationCodeReceived\ before the native handler
2. Read \ClientCertificates\ from \MicrosoftIdentityOptions\ (injected by CD from Key Vault)
3. Generate a signed \client_assertion\ JWT using the certificate private key
4. Exchange the authorization code at the token endpoint with the \client_assertion\

## Tests

All 205 tests pass.