### PR TITLE
fix(cd): use correct CredentialDescription property name for base64 cert

### DIFF
--- a/.github/workflows/cd-backend.yml
+++ b/.github/workflows/cd-backend.yml
@@ -236,7 +236,7 @@ jobs:
                 - AzureAd__TenantId=$env:AZURE_AD_TENANT_ID
                 - AzureAd__ClientId=$env:AZURE_AD_CLIENT_ID
                 - AzureAd__ClientCertificates__0__SourceType=Base64Encoded
-                - AzureAd__ClientCertificates__0__CertificateBase64Value=${CertBase64}
+                - AzureAd__ClientCertificates__0__Base64EncodedValue=${CertBase64}
               ports:
                 - "8080:8080"
               networks:


### PR DESCRIPTION
## Summary

Fixes #351 (final piece)

## Root Cause

The CD pipeline was injecting the certificate as:
\\\
AzureAd__ClientCertificates__0__CertificateBase64Value=\
\\\

But \Microsoft.Identity.Abstractions.CredentialDescription\ uses \Base64EncodedValue\ as the property name (not \CertificateBase64Value\). This caused MSAL to see an empty string and throw:

> IDW10109: No credential could be loaded ... Credential CertificateFromBase64Encoded=;Thumbprint=null failed because: System.ArgumentNullException: Value cannot be null. (Parameter 's')

## Fix

One-character rename in the generated \docker-compose.prod.yml\ env var:
\\\diff
- AzureAd__ClientCertificates__0__CertificateBase64Value=\
+ AzureAd__ClientCertificates__0__Base64EncodedValue=\
\\\

## Timeline

1. #352 — switched \AddOpenIdConnect\ → \AddMicrosoftIdentityWebApp\ (necessary but insufficient)
2. #353 — added \EnableTokenAcquisitionToCallDownstreamApi()\ so MSAL intercepts \OnAuthorizationCodeReceived\
3. This PR — fixes the env var name so MSAL can actually load the cert