### PR TITLE
feat(theme): add dark/light mode toggle to page shell

### DIFF
--- a/src/ui/web/projects/menlo-lib/src/lib/organisms/page-shell/page-shell.component.spec.ts
+++ b/src/ui/web/projects/menlo-lib/src/lib/organisms/page-shell/page-shell.component.spec.ts
@@ -1,8 +1,9 @@
-import { Component, provideZonelessChangeDetection } from '@angular/core';
+import { Component, provideZonelessChangeDetection, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { provideRouter, Router } from '@angular/router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { type Theme, ThemeService } from '../../theme';
 import { MnlPageShellComponent } from './page-shell.component';
 
 @Component({
@@ -29,7 +30,13 @@ class TestHostComponent {
 }
 
 describe('MnlPageShellComponent', () => {
+  const currentTheme = signal<Theme>('light');
+  const toggleTheme = vi.fn();
+
   beforeEach(async () => {
+    currentTheme.set('light');
+    toggleTheme.mockReset();
+
     await TestBed.configureTestingModule({
       imports: [TestHostComponent],
       providers: [
@@ -39,6 +46,13 @@ describe('MnlPageShellComponent', () => {
           { path: 'analytics', component: DummyRouteComponent },
         ]),
         provideZonelessChangeDetection(),
+        {
+          provide: ThemeService,
+          useValue: {
+            currentTheme,
+            toggle: toggleTheme,
+          } satisfies Pick<ThemeService, 'currentTheme' | 'toggle'>,
+        },
       ],
     }).compileComponents();
   });
@@ -61,6 +75,31 @@ describe('MnlPageShellComponent', () => {
     expect(container?.className).toContain('px-4');
     expect(container?.className).toContain('lg:px-8');
     expect(container?.className).toContain('max-w-screen-2xl');
+  });
+
+  it('renders a theme toggle button and toggles the theme when clicked', async () => {
+    const fixture = TestBed.createComponent(TestHostComponent);
+    const router = TestBed.inject(Router);
+
+    await router.navigateByUrl('/');
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    const button = host.querySelector(
+      '[data-testid="mnl-page-shell-theme-toggle"]',
+    ) as HTMLButtonElement | null;
+
+    expect(button).toBeTruthy();
+    expect(button?.getAttribute('aria-label')).toBe('Switch to dark mode');
+
+    button?.click();
+
+    expect(toggleTheme).toHaveBeenCalledTimes(1);
+
+    currentTheme.set('dark');
+    fixture.detectChanges();
+
+    expect(button?.getAttribute('aria-label')).toBe('Switch to light mode');
   });
 
   it('scrolls the content viewport to the top after navigation completes', async () => {

--- a/src/ui/web/projects/menlo-lib/src/lib/organisms/page-shell/page-shell.component.ts
+++ b/src/ui/web/projects/menlo-lib/src/lib/organisms/page-shell/page-shell.component.ts
@@ -3,19 +3,22 @@ import {
   Component,
   ElementRef,
   ViewChild,
+  computed,
   inject,
   input,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NavigationEnd, Router } from '@angular/router';
+import { LucideAngularModule, Moon, Sun } from 'lucide-angular';
 import { filter } from 'rxjs';
 
 import { MnlTabBarComponent, type MnlTabBarItem } from '../../molecules/tab-bar';
+import { ThemeService } from '../../theme';
 
 @Component({
   selector: 'mnl-page-shell',
   standalone: true,
-  imports: [MnlTabBarComponent],
+  imports: [LucideAngularModule, MnlTabBarComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'block min-h-dvh bg-mnl-bg text-mnl-text',
@@ -25,6 +28,24 @@ import { MnlTabBarComponent, type MnlTabBarItem } from '../../molecules/tab-bar'
       <mnl-tab-bar [items]="items()" />
 
       <div class="flex min-h-dvh min-w-0 flex-1 flex-col">
+        <header class="border-b border-mnl-border bg-mnl-surface/90 backdrop-blur supports-[backdrop-filter]:bg-mnl-surface/80">
+          <div class="mx-auto flex w-full max-w-screen-2xl justify-end px-4 py-3 sm:px-6 lg:px-8">
+            <button
+              type="button"
+              class="inline-flex size-10 items-center justify-center rounded-full border border-mnl-border bg-mnl-surface text-[--mnl-subtext] transition-colors duration-200 hover:bg-mnl-surface-alt hover:text-[--mnl-text] focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-mnl-accent focus-visible:ring-offset-2 focus-visible:ring-offset-mnl-bg motion-reduce:transition-none"
+              data-testid="mnl-page-shell-theme-toggle"
+              [attr.aria-label]="isDarkTheme() ? 'Switch to light mode' : 'Switch to dark mode'"
+              (click)="toggleTheme()"
+            >
+              <lucide-icon
+                [img]="isDarkTheme() ? sunIcon : moonIcon"
+                aria-hidden="true"
+                class="size-5"
+              ></lucide-icon>
+            </button>
+          </div>
+        </header>
+
         <div
           #contentViewport
           class="flex-1 overflow-y-auto pb-24 lg:pb-0"
@@ -48,6 +69,12 @@ export class MnlPageShellComponent {
   private readonly contentViewport?: ElementRef<HTMLElement>;
 
   private readonly router = inject(Router, { optional: true });
+  private readonly themeService = inject(ThemeService);
+
+  protected readonly currentTheme = this.themeService.currentTheme;
+  protected readonly isDarkTheme = computed(() => this.currentTheme() === 'dark');
+  protected readonly moonIcon = Moon;
+  protected readonly sunIcon = Sun;
 
   constructor() {
     this.router?.events
@@ -56,6 +83,10 @@ export class MnlPageShellComponent {
         takeUntilDestroyed(),
       )
       .subscribe(() => this.scrollContentToTop());
+  }
+
+  protected toggleTheme(): void {
+    this.themeService.toggle();
   }
 
   private scrollContentToTop(): void {

--- a/src/ui/web/projects/menlo-lib/src/lib/organisms/page-shell/page-shell.stories.ts
+++ b/src/ui/web/projects/menlo-lib/src/lib/organisms/page-shell/page-shell.stories.ts
@@ -53,7 +53,7 @@ class DummyStoryRouteComponent {}
           <h1 class="mt-2 mb-0 text-3xl font-bold tracking-tight">Page Shell</h1>
           <p class="mt-3 mb-0 max-w-3xl text-sm leading-6 text-mnl-subtext">
             The page shell composes the responsive navigation scaffold with a padded, max-width
-            content column that stays scrollable across route changes.
+            content column, route-aware scroll reset, and a built-in theme toggle.
           </p>
         </section>
 
@@ -74,7 +74,7 @@ class DummyStoryRouteComponent {}
                     <h2 class="m-0 text-3xl font-bold tracking-tight">Household dashboard</h2>
                     <p class="m-0 max-w-3xl text-sm leading-6 text-mnl-subtext">
                       Page content remains centered, padded, and scrollable while navigation adapts
-                      to the current viewport.
+                      to the current viewport and the shell keeps the theme toggle within reach.
                     </p>
                   </header>
 


### PR DESCRIPTION
Adds a sun/moon toggle button to MnlPageShellComponent so users can manually switch between light (Latte) and dark (Mocha) themes.

Closes #320